### PR TITLE
Correct capitalization of classname in package.xml

### DIFF
--- a/package.xml
+++ b/package.xml
@@ -12,7 +12,7 @@
   <content>
     <workbench>
       <name>MOOC</name>
-      <classname>MOOCWorkbench</classname>
+      <classname>MoocWorkbench</classname>
       <subdirectory>./</subdirectory>
       <freecadmin>0.19.0</freecadmin>
     </workbench>


### PR DESCRIPTION
Must match the classname in InitGui.py.