### PR TITLE
Make license match SPDX ID

### DIFF
--- a/package.xml
+++ b/package.xml
@@ -4,7 +4,7 @@
   <description>Learn FreeCAD</description>
   <version>2022.04.21</version>
   <maintainer email="contact@freecad-france.com">Jonathan Wiedemann</maintainer>
-  <license file="LICENSE">GPLv2.1</license>
+  <license file="LICENSE">GPL-2.0-or-later</license>
   <url type="repository" branch="master">https://github.com/j-wiedemann/mooc-workbench</url>
   <url type="website">https://www.fun-mooc.fr/fr/cours/modeliser-en-3d-avec-freecad/</url>
   <icon>medias/icons/mooc-workbench.svg</icon>


### PR DESCRIPTION
See https://spdx.org/licenses/ -- note that you might actually mean `GPL-2.0-only`, in which case use that instead. There is not a "GPL 2.1" -- did you actually mean to use the "**L**GPL 2.1" license?
